### PR TITLE
added auto-approve flag

### DIFF
--- a/.github/workflows/demo-app-build-and-deploy.yml
+++ b/.github/workflows/demo-app-build-and-deploy.yml
@@ -60,6 +60,7 @@ jobs:
         uses: dflook/terraform-apply@v1
         with:
           path: terraform/demo-app
+          auto_approve: true
           backend_config: |
             username=${{secrets.ARTIFACTORY_USERNAME}}
             password=${{secrets.ARTIFACTORY_PASSWORD}}


### PR DESCRIPTION
## Summary
Workflow dispatch is not related to a pr so the terraform apply action could not fetch a plan. so adding the auto-approve flag so that we can run the workflow outside of pr merge event
<!-- 
What are the main issue this PR is trying to solve?
Give a high-level description of the changes.
#Examples: Added a new Camunda workflow to support the Telework flow.
-->

## Changes
<!-- 
What are the main changes in the PR?
List out the bigger changes made
#Examples:
- Added a search feature in web app
- Renamed DB fields
-->

## Screenshots (if applicable)
<!-- 
Add screenshots highlighting the changes.
-->

## Notes
<!-- You can add any concerns highlighted during code review that cannot be addressed, any limitations in the changes, any subsequent actions to be taken, or anything noteworthy about the change that a reviewer would benefit from etc.-->