### PR TITLE
[ON HOLD - causing keycloak crush in dev]: added post logout redirect uri in demo app

### DIFF
--- a/demo-app/Program.cs
+++ b/demo-app/Program.cs
@@ -54,6 +54,11 @@ builder.Services.AddAuthentication(options =>
                 n.ProtocolMessage.RedirectUri = keycloakRedirectUri + "/signin-oidc";
                 await Task.FromResult(0);
             };
+        options.Events.OnRedirectToIdentityProviderForSignOut = async n =>
+            {
+                await options.Events.OnRedirectToIdentityProvider(n);
+                n.ProtocolMessage.PostLogoutRedirectUri = keycloakRedirectUri + "/signout-callback-oidc";
+            };
     }); 
 
 


### PR DESCRIPTION
## Summary
by default dotnet used `http` in the post logout redirect uri which is not a valid redirect uri in keycloak. this change specifies to use `https`. which should fix the logout issue. 
<!-- 
What are the main issue this PR is trying to solve?
Give a high-level description of the changes.
#Examples: Added a new Camunda workflow to support the Telework flow.
-->

## Changes
<!-- 
What are the main changes in the PR?
List out the bigger changes made
#Examples:
- Added a search feature in web app
- Renamed DB fields
-->

## Screenshots (if applicable)
<!-- 
Add screenshots highlighting the changes.
-->

## Notes
<!-- You can add any concerns highlighted during code review that cannot be addressed, any limitations in the changes, any subsequent actions to be taken, or anything noteworthy about the change that a reviewer would benefit from etc.-->